### PR TITLE
Update auth api for language preference

### DIFF
--- a/lib/features/auth/data/data_sources/remote/auth_remote_datasource.dart
+++ b/lib/features/auth/data/data_sources/remote/auth_remote_datasource.dart
@@ -18,7 +18,7 @@ abstract class AuthRemoteDatasource {
     required ValidateOtpRequest request,
   });
 
-  Future<AppConfigModel> guestMode();
+  Future<AppConfigModel> guestMode({String? languagePreference});
 
   Future<TokensModel> addUserInformation({
     required AddUserInfoRequest request,

--- a/lib/features/auth/data/data_sources/remote/auth_remote_datasource_impl.dart
+++ b/lib/features/auth/data/data_sources/remote/auth_remote_datasource_impl.dart
@@ -49,11 +49,14 @@ class AuthRemoteDatasourceImpl extends AuthRemoteDatasource {
   }
 
   @override
-  Future<AppConfigModel> guestMode() async {
+  Future<AppConfigModel> guestMode({String? languagePreference}) async {
     return await _apiConsumer.get<AppConfigModel>(
       ApiConstants.appConfig,
       responseReturnType: ResponseReturnType.fromJson,
       fromJsonMethod: AppConfigModel.fromJson,
+      queryParameters: languagePreference != null
+          ? {AppConstants.lang: languagePreference}
+          : null,
     );
   }
 

--- a/lib/features/auth/data/repositories/auth_repository.dart
+++ b/lib/features/auth/data/repositories/auth_repository.dart
@@ -20,7 +20,10 @@ abstract class AuthRepository {
     required ValidateOtpRequest request,
   });
 
-  Future<Either<Failure, AppConfigModel>> guestMode({bool isClicked = false});
+  Future<Either<Failure, AppConfigModel>> guestMode({
+    bool isClicked = false,
+    String? languagePreference,
+  });
 
   Future<Either<Failure, TokensModel>> addUserInformation({
     required AddUserInfoRequest request,

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -67,9 +67,14 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
-  Future<Either<Failure, AppConfigModel>> guestMode({bool isClicked = false}) async {
+  Future<Either<Failure, AppConfigModel>> guestMode({
+    bool isClicked = false,
+    String? languagePreference,
+  }) async {
     try {
-      AppConfigModel response = await _remoteDatasource.guestMode();
+      AppConfigModel response = await _remoteDatasource.guestMode(
+        languagePreference: languagePreference,
+      );
       AppConfigManager.config = response;
       ///from API
       _localDatasource.storeGuestModeSession(response.guestMode);

--- a/lib/features/auth/data/requests/send_otp_request.dart
+++ b/lib/features/auth/data/requests/send_otp_request.dart
@@ -6,8 +6,13 @@ part 'send_otp_request.g.dart';
 class SendOtpRequest {
   @JsonKey(name: "phoneNumber")
   final String phoneNumber;
+  @JsonKey(name: "languagePreference", includeIfNull: false)
+  final String? languagePreference;
 
-  const SendOtpRequest({required this.phoneNumber});
+  const SendOtpRequest({
+    required this.phoneNumber,
+    this.languagePreference,
+  });
 
   factory SendOtpRequest.fromJson(Map<String, dynamic> json) =>
       _$SendOtpRequestFromJson(json);

--- a/lib/features/auth/data/requests/send_otp_request.g.dart
+++ b/lib/features/auth/data/requests/send_otp_request.g.dart
@@ -9,9 +9,20 @@ part of 'send_otp_request.dart';
 SendOtpRequest _$SendOtpRequestFromJson(Map<String, dynamic> json) =>
     SendOtpRequest(
       phoneNumber: json['phoneNumber'] as String,
+      languagePreference: json['languagePreference'] as String?,
     );
 
-Map<String, dynamic> _$SendOtpRequestToJson(SendOtpRequest instance) =>
-    <String, dynamic>{
-      'phoneNumber': instance.phoneNumber,
-    };
+Map<String, dynamic> _$SendOtpRequestToJson(SendOtpRequest instance) {
+  final val = <String, dynamic>{
+    'phoneNumber': instance.phoneNumber,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('languagePreference', instance.languagePreference);
+  return val;
+}

--- a/lib/features/auth/logic/auth_cubit.dart
+++ b/lib/features/auth/logic/auth_cubit.dart
@@ -33,6 +33,7 @@ class AuthCubit extends Cubit<AuthState> {
     emit(AuthLoadingState());
     final request = SendOtpRequest(
       phoneNumber: phoneNumber ?? this.phoneNumber,
+      languagePreference: _getCurrentLanguageCode(),
     );
     final result = await _authRepository.sendOtp(request);
     result.fold(
@@ -54,7 +55,7 @@ class AuthCubit extends Cubit<AuthState> {
     final request = ValidateOtpRequest(
       phoneNumber: phoneNumber,
       otpCode: otpCode,
-      lang: authModel.isNewUser ? null : _getCurrentLanguageCode(),
+      lang: _getCurrentLanguageCode(),
     );
 
     if (authModel.isNewUser) {
@@ -86,7 +87,10 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> appConfig({bool isGuestModeClicked = false}) async {
     emit(GuestModeLoadingState());
 
-    final result = await _authRepository.guestMode(isClicked:isGuestModeClicked );
+    final result = await _authRepository.guestMode(
+      isClicked: isGuestModeClicked,
+      languagePreference: _getCurrentLanguageCode(),
+    );
     result.fold(
       (failure) {
         emit(GuestModeFailureState(failure.message));

--- a/lib/features/auth/presentation/screens/auth_screen.dart
+++ b/lib/features/auth/presentation/screens/auth_screen.dart
@@ -6,6 +6,8 @@ import 'package:dazzify/core/util/validation_manager.dart';
 import 'package:dazzify/features/auth/data/data_sources/local/auth_local_datasource_impl.dart';
 import 'package:dazzify/features/auth/logic/auth_cubit.dart';
 import 'package:dazzify/features/auth/presentation/widgets/auth_header.dart';
+import 'package:dazzify/features/shared/logic/settings/settings_cubit.dart';
+import 'package:dazzify/features/shared/logic/settings/settings_state.dart';
 import 'package:dazzify/features/shared/widgets/dazzify_text_form_field.dart';
 import 'package:dazzify/features/shared/widgets/dazzify_toast_bar.dart';
 import 'package:dazzify/features/shared/widgets/primary_button.dart';
@@ -52,7 +54,57 @@ class _AuthScreenState extends State<AuthScreen> {
         child: Column(
           children: [
             const AuthHeader(isLogoAnimated: true),
-            const Spacer(flex: 1),
+            BlocBuilder<SettingsCubit, SettingsState>(
+              builder: (context, settingsState) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 14.0).r,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      InkWell(
+                        onTap: () {
+                          final newLanguage = settingsState.currentLanguageCode == AppConstants.enCode
+                              ? AppConstants.arCode
+                              : AppConstants.enCode;
+                          context.read<SettingsCubit>().changeAppLanguage(
+                                languageCode: newLanguage,
+                              );
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 6,
+                          ).r,
+                          decoration: BoxDecoration(
+                            color: context.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(20).r,
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              DText(
+                                settingsState.currentLanguageCode == AppConstants.enCode
+                                    ? AppConstants.usFlag
+                                    : AppConstants.egyptFlag,
+                                style: context.textTheme.bodyMedium,
+                              ),
+                              SizedBox(width: 6.w),
+                              DText(
+                                settingsState.currentLanguageCode == AppConstants.enCode
+                                    ? context.tr.english
+                                    : context.tr.arabic,
+                                style: context.textTheme.bodySmall,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            SizedBox(height: 20.h),
             Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: 14.0,


### PR DESCRIPTION
Implement language preference selection on the auth screen and integrate it into auth and guest mode API calls to allow users to choose their preferred language, especially for first-time app users.

---
<a href="https://cursor.com/background-agent?bcId=bc-e86b1643-5d0f-4e5b-9de8-285049f88db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e86b1643-5d0f-4e5b-9de8-285049f88db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

