### PR TITLE
Initialize current language code in settings cubit

### DIFF
--- a/lib/features/shared/logic/settings/settings_cubit.dart
+++ b/lib/features/shared/logic/settings/settings_cubit.dart
@@ -13,7 +13,9 @@ class SettingsCubit extends Cubit<SettingsState> {
   late String currentLanguageCode;
   late bool isDarkTheme;
 
-  SettingsCubit(this._localRepository) : super(const SettingsState());
+  SettingsCubit(this._localRepository) : super(const SettingsState()) {
+    currentLanguageCode = AppConstants.enCode;
+  }
 
   void checkAppTheme() {
     try {


### PR DESCRIPTION
Initialize `currentLanguageCode` in `SettingsCubit` to prevent `LateInitializationError` when `AuthCubit` accesses it early.

---
<a href="https://cursor.com/background-agent?bcId=bc-db70ec27-5daa-4cd5-ac7a-341e8db499ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db70ec27-5daa-4cd5-ac7a-341e8db499ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

