### PR TITLE
Fix white screen on language change

### DIFF
--- a/lib/dazzify_app.dart
+++ b/lib/dazzify_app.dart
@@ -108,7 +108,7 @@ class _DazzifyAppState extends State<DazzifyApp> {
                     DazzifyApp.tr = context.tr;
                     return DazzifyApp.tr.appName;
                   },
-                  locale: Locale(settingsCubit.currentLanguageCode),
+                  locale: Locale(state.currentLanguageCode),
                   supportedLocales: S.delegate.supportedLocales,
                   theme: state.isDarkTheme
                       ? ThemeManager.darkTheme()

--- a/lib/features/user/presentation/screens/profile_screen.dart
+++ b/lib/features/user/presentation/screens/profile_screen.dart
@@ -10,7 +10,6 @@ import 'package:dazzify/features/user/presentation/components/profile/profile_he
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:restart/restart.dart';
 
 @RoutePage()
 class ProfileScreen extends StatefulWidget {
@@ -40,11 +39,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
         if (state.updateProfileLangState == UiState.loading) {
           isLoading.value = true;
         } else if (state.updateProfileLangState == UiState.success) {
+          isLoading.value = false;
           settingsCubit.changeAppLanguage(
             languageCode: state.updatedLanguageCode,
           );
-          // await NotificationsService.close();
-          restart();
         } else {
           isLoading.value = false;
           DazzifyToastBar.showError(


### PR DESCRIPTION
Fixes white screen on iPhone when changing language by removing `restart()` call and making `MaterialApp.locale` reactive to language state changes.

The white screen occurred because `restart()` was forcing a full app restart, and `MaterialApp` was not rebuilding with the new locale as it was reading directly from a cubit field instead of the reactive state. This PR ensures a smooth language transition without restarting the app.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e79d4d0-9fe3-42e1-8918-f7447e467b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e79d4d0-9fe3-42e1-8918-f7447e467b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

