### PR TITLE
Search page refresh and loading

### DIFF
--- a/lib/features/home/logic/search/search_bloc.dart
+++ b/lib/features/home/logic/search/search_bloc.dart
@@ -164,9 +164,11 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     }
   }
 
-  void onRefreshEvent(RefreshEvent event, Emitter<SearchState> emit) {
+  Future<void> onRefreshEvent(RefreshEvent event, Emitter<SearchState> emit) async {
     _mediaPage = 1;
     _brandsPage = 1;
     emit(const SearchState());
+    // Fetch media items after refresh
+    add(GetMediaItemsEvent());
   }
 }


### PR DESCRIPTION
Trigger `GetMediaItemsEvent` on refresh to prevent the Search Page from getting stuck in a loading state.

---
<a href="https://cursor.com/background-agent?bcId=bc-726a627d-8b25-415c-a564-210697a3bb2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-726a627d-8b25-415c-a564-210697a3bb2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

