### PR TITLE
Implement share service with gray screen

### DIFF
--- a/lib/features/brand/logic/brand/brand_bloc.dart
+++ b/lib/features/brand/logic/brand/brand_bloc.dart
@@ -86,6 +86,7 @@ class BrandBloc extends Bloc<BrandEvent, BrandState> {
           ),
         );
         add(GetBrandImagesEvent(brandDetails.id));
+        add(GetBrandReelsEvent(brandDetails.id));
         add(AddBrandViewEvent(brandDetails.id));
       },
     );

--- a/lib/features/brand/presentation/screens/brand_profile_screen.dart
+++ b/lib/features/brand/presentation/screens/brand_profile_screen.dart
@@ -69,13 +69,13 @@ class _BrandProfileScreenState extends State<BrandProfileScreen>
     _tabController = TabController(length: 3, vsync: this);
     _controller = ScrollController();
     _brandBloc = context.read<BrandBloc>();
-    _brandBloc.add(GetBrandImagesEvent(widget.brand!.id));
-    _brandBloc.add(GetBrandReelsEvent(widget.brand!.id));
 
     if (widget.brand != null) {
       _brandBloc.add(
         SetSingleBrandDetailsEvent(widget.brand!),
       );
+      _brandBloc.add(GetBrandImagesEvent(widget.brand!.id));
+      _brandBloc.add(GetBrandReelsEvent(widget.brand!.id));
     } else {
       _brandBloc.add(
         GetSingleBrandDetailsEvent(widget.brandSlug!),


### PR DESCRIPTION
Fix gray screen when opening shared brand/service links by handling null `widget.brand` and ensuring reels load for deep links.

When a brand or service link was shared and opened via a deep link, only the `brandSlug` was available, making `widget.brand` null. The `BrandProfileScreen` was attempting to access `widget.brand!.id` in its `initState` before the brand details were fetched, leading to a null pointer exception and a gray screen. Additionally, reels were not being loaded when a brand was accessed through a deep link. This PR ensures that image and reel fetching is conditional on `widget.brand` being available or triggered after brand details are fetched for deep links.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c91a9f1-25e5-4431-99b2-7d3b5cbb7123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c91a9f1-25e5-4431-99b2-7d3b5cbb7123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

