### PR TITLE
Retrieve full terms and notes

### DIFF
--- a/lib/features/auth/presentation/bottom_sheets/app_terms_bottom_sheet.dart
+++ b/lib/features/auth/presentation/bottom_sheets/app_terms_bottom_sheet.dart
@@ -108,7 +108,6 @@ class _AppTermsBottomSheetState extends State<AppTermsBottomSheet> {
                                 child: DText(
                                   state.appTerms[index],
                                   softWrap: true,
-                                  maxLines: 10,
                                   style: context.textTheme.bodySmall!.copyWith(
                                     color: context.colorScheme.onSurfaceVariant,
                                   ),

--- a/lib/features/booking/presentation/bottom_sheets/brand_terms_sheet.dart
+++ b/lib/features/booking/presentation/bottom_sheets/brand_terms_sheet.dart
@@ -171,7 +171,6 @@ class _BrandTermsSheetState extends State<BrandTermsSheet> {
                                           child: DText(
                                             state.brandTerms[index],
                                             softWrap: true,
-                                            maxLines: 8,
                                             style: context.textTheme.bodySmall!.copyWith(
                                               color: context.colorScheme.onSurfaceVariant,
                                             ),

--- a/lib/features/user/presentation/bottom_sheets/cancel_terms_bottom_sheet.dart
+++ b/lib/features/user/presentation/bottom_sheets/cancel_terms_bottom_sheet.dart
@@ -96,7 +96,6 @@ class _CancelTermsBottomSheetState extends State<CancelTermsBottomSheet> {
                               SizedBox(width: 3.w),
                               Flexible(
                                 child: DText(
-                                  maxLines: 5,
                                   widget.refundConditions[index],
                                   softWrap: true,
                                   style: context.textTheme.bodySmall!.copyWith(

--- a/lib/features/user/presentation/widgets/booking_info_item.dart
+++ b/lib/features/user/presentation/widgets/booking_info_item.dart
@@ -77,7 +77,6 @@ class BookingInfoItem extends StatelessWidget {
                         width: 160.w,
                         child: DText(
                           subtitle,
-                          maxLines: 3,
                           style: context.textTheme.bodySmall!.copyWith(
                             color: context.colorScheme.onSurfaceVariant,
                           ),
@@ -100,7 +99,6 @@ class BookingInfoItem extends StatelessWidget {
                   width: 200.w,
                   child: DText(
                       subtitle,
-                      maxLines: 2,
                       style: context.textTheme.bodySmall!.copyWith(
                         color: context.colorScheme.onSurfaceVariant,
                       ),


### PR DESCRIPTION
Remove `maxLines` attributes from various text widgets to display full content instead of truncated text.

---
<a href="https://cursor.com/background-agent?bcId=bc-774aa50e-81e2-49d7-98d6-14be08306c3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-774aa50e-81e2-49d7-98d6-14be08306c3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

