### PR TITLE
Manage booking cancel button visibility

### DIFF
--- a/lib/features/user/presentation/components/booking/booking_status_header_component.dart
+++ b/lib/features/user/presentation/components/booking/booking_status_header_component.dart
@@ -97,36 +97,41 @@ class _BookingStatusHeaderComponentState
   Widget buildStatusButton() {
     final startTime = DateTime.parse(widget.startTime).toLocal();
     final now = DateTime.now();
-    // bool isToday = startTime.year == now.year &&
-    //     startTime.month == now.month &&
-    //     startTime.day == now.day;
+    final minutesUntilBooking = getTimeInMinute();
 
-    bool isSwiped = getTimeInMinute() <= 0 &&
-        widget.status == BookingStatus.confirmed &&
-        widget.isBookingFinished;
-
+    // If booking is finished, show review button
     if (widget.isBookingFinished) {
       return rateBookingButton();
-    } else if
-    // (
-    // (widget.status == BookingStatus.pending) ||
-    //     (widget.status != BookingStatus.cancelled &&
-    //         !widget.isBookingFinished &&
-    //         !widget.isArrived
-    //         &&getTimeInMinute() <= 0
-    //     // &&
-    //     // !isToday
-    //     ) ||
-    //     isSwiped)
-         (!(getTimeInMinute() <= 60 &&
-        // getTimeInMinute() < 0 &&
-        widget.status == BookingStatus.confirmed &&
-        !widget.isArrived))
-    {
-      return cancelBookingButton();
-    } else {
+    }
+
+    // If booking is cancelled, hide cancel button
+    if (widget.status == BookingStatus.cancelled) {
       return const SizedBox.shrink();
     }
+
+    // If booking is pending, show cancel button
+    if (widget.status == BookingStatus.pending) {
+      return cancelBookingButton();
+    }
+
+    // If booking is confirmed
+    if (widget.status == BookingStatus.confirmed) {
+      // If user has arrived, hide cancel button
+      if (widget.isArrived) {
+        return const SizedBox.shrink();
+      }
+
+      // If booking time has passed, hide cancel button
+      if (minutesUntilBooking <= 0) {
+        return const SizedBox.shrink();
+      }
+
+      // Before booking time and not arrived, show cancel button
+      return cancelBookingButton();
+    }
+
+    // Default: hide button
+    return const SizedBox.shrink();
   }
 
   Widget rateBookingButton() {


### PR DESCRIPTION
Refactor booking status button visibility logic to correctly show/hide the cancel button based on booking status and time.

The previous logic incorrectly displayed the cancel button for cancelled bookings and after the booking time had passed for confirmed bookings. This PR implements a clear, case-by-case logic to ensure the cancel button is only visible when the booking is pending, or confirmed (before the booking time starts and the user has not arrived).

---
<a href="https://cursor.com/background-agent?bcId=bc-da43df16-2af4-4aa0-827d-feed22a921d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da43df16-2af4-4aa0-827d-feed22a921d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

