### PR TITLE
Handle text overflow with new lines

### DIFF
--- a/lib/features/user/presentation/screens/booking_status_screen.dart
+++ b/lib/features/user/presentation/screens/booking_status_screen.dart
@@ -306,8 +306,7 @@ Widget serviceInfo(BuildContext context, BookingCubit booking) {
                 style: context.textTheme.bodySmall!.copyWith(
                   color: context.colorScheme.onSurfaceVariant,
                 ),
-                maxLines: 3,
-                overflow: TextOverflow.ellipsis,
+                softWrap: true,
               ),
             ),
           ],

--- a/lib/features/user/presentation/widgets/multi_booking_widget.dart
+++ b/lib/features/user/presentation/widgets/multi_booking_widget.dart
@@ -83,9 +83,8 @@ class MultiBookingWidget extends StatelessWidget {
                         Expanded(
                           child: DText(
                             service.title,
-                            style: context.textTheme.bodyLarge!.copyWith(
-                              overflow: TextOverflow.ellipsis,
-                            ),
+                            style: context.textTheme.bodyLarge,
+                            softWrap: true,
                           ),
                         ),
                         SizedBox(
@@ -101,11 +100,8 @@ class MultiBookingWidget extends StatelessWidget {
                     ),
                     Text(
                       service.description,
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
                       style: context.textTheme.bodySmall!.copyWith(
                         color: context.colorScheme.onSurfaceVariant,
-                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ],


### PR DESCRIPTION
Remove text overflow ellipsis and max lines to display full text with line wrapping in service descriptions and titles.

The user requested that text fields should not truncate with ellipsis but instead wrap to new lines to show the complete content. This PR addresses this by modifying the `booking_status_screen.dart` and `multi_booking_widget.dart` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-816700ad-641b-4e3a-9679-232e0b51aa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-816700ad-641b-4e3a-9679-232e0b51aa46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

