### PR TITLE
Enable text wrapping in booking widgets

### DIFF
--- a/lib/features/user/presentation/screens/booking_status_screen.dart
+++ b/lib/features/user/presentation/screens/booking_status_screen.dart
@@ -306,8 +306,7 @@ Widget serviceInfo(BuildContext context, BookingCubit booking) {
                 style: context.textTheme.bodySmall!.copyWith(
                   color: context.colorScheme.onSurfaceVariant,
                 ),
-                maxLines: 3,
-                overflow: TextOverflow.ellipsis,
+                softWrap: true,
               ),
             ),
           ],


### PR DESCRIPTION
Enable text wrapping for service descriptions in the booking status screen to prevent text truncation.

---
<a href="https://cursor.com/background-agent?bcId=bc-fea2d6ca-47ca-4d92-98c1-d721d41c1748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fea2d6ca-47ca-4d92-98c1-d721d41c1748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

