### PR TITLE
Fix language change text update issue

### DIFF
--- a/lib/core/api/dio_consumer.dart
+++ b/lib/core/api/dio_consumer.dart
@@ -5,6 +5,7 @@ import 'package:dartz/dartz.dart';
 import 'package:dazzify/core/api/api_consumer.dart';
 import 'package:dazzify/core/api/api_status_codes.dart';
 import 'package:dazzify/core/api/base_response.dart';
+import 'package:dazzify/core/api/dio_language_interceptor.dart';
 import 'package:dazzify/core/api/dio_tokens_interceptor.dart';
 import 'package:dazzify/core/config/build_config.dart';
 import 'package:dazzify/core/constants/app_constants.dart';
@@ -37,6 +38,7 @@ class DioApiConsumer extends ApiConsumer {
       ..validateStatus =
           (status) => status! < ApiStatusCodes.internalServerError;
 
+    dioClient.interceptors.add(DioLanguageInterceptor());
     dioClient.interceptors.add(getIt<DioTokenInterceptor>());
 
     dioClient.interceptors.add(

--- a/lib/core/api/dio_language_interceptor.dart
+++ b/lib/core/api/dio_language_interceptor.dart
@@ -1,0 +1,23 @@
+import 'package:dazzify/core/injection/injection.dart';
+import 'package:dazzify/features/shared/logic/settings/settings_cubit.dart';
+import 'package:dio/dio.dart';
+
+class DioLanguageInterceptor extends Interceptor {
+  DioLanguageInterceptor();
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    try {
+      // Get current language from SettingsCubit
+      final currentLanguage = getIt<SettingsCubit>().currentLanguageCode;
+      
+      // Add Accept-Language header
+      options.headers['Accept-Language'] = currentLanguage;
+    } catch (e) {
+      // If we can't get the language, continue without it
+      // This shouldn't break the request
+    }
+    
+    handler.next(options);
+  }
+}

--- a/lib/features/bottom_nav_bar/bottom_nav_bar.dart
+++ b/lib/features/bottom_nav_bar/bottom_nav_bar.dart
@@ -136,6 +136,27 @@ class _BottomNavBarState extends State<BottomNavBar>
             }
           },
         ),
+        BlocListener<SettingsCubit, SettingsState>(
+          listenWhen: (previous, current) =>
+              previous.currentLanguageCode != current.currentLanguageCode,
+          listener: (context, state) {
+            // When language changes, refetch data for all screens
+            // Clear cached data
+            mainCategories.clear();
+            
+            // Refetch home data
+            context.read<HomeCubit>()
+              ..getBanners()
+              ..getMainCategories()
+              ..getPopularBrands()
+              ..getTopRatedBrands()
+              ..getPopularServices()
+              ..getTopRatedServices();
+            
+            // Refetch booking data
+            context.read<BookingCubit>().getLastActiveBookings();
+          },
+        ),
       ],
       child: AutoTabsScaffold(
         resizeToAvoidBottomInset: false,

--- a/lib/features/user/presentation/screens/profile_screen.dart
+++ b/lib/features/user/presentation/screens/profile_screen.dart
@@ -40,7 +40,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
           isLoading.value = true;
         } else if (state.updateProfileLangState == UiState.success) {
           isLoading.value = false;
-          settingsCubit.changeAppLanguage(
+          // Update local language setting - this will trigger the BlocListener in bottom_nav_bar
+          // which will refetch all data with the new language
+          await settingsCubit.changeAppLanguage(
             languageCode: state.updatedLanguageCode,
           );
         } else {


### PR DESCRIPTION
Fixes API-fetched texts not updating on language change by adding language headers to API requests and refetching data globally.

Previously, API requests did not include the `Accept-Language` header, causing the backend to return data in the old language. Additionally, cached data was not cleared, and screens did not refetch data after a language change, leading to stale content until a manual refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f7ac1de-25eb-4670-9990-a6a330fbe104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f7ac1de-25eb-4670-9990-a6a330fbe104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

