### PR TITLE
Fetch and display privacy policies

### DIFF
--- a/PRIVACY_POLICY_IMPLEMENTATION.md
+++ b/PRIVACY_POLICY_IMPLEMENTATION.md
@@ -1,0 +1,183 @@
+# Privacy Policy Feature Implementation
+
+## Overview
+This document describes the complete privacy policy feature that has been implemented to fetch and display privacy policies from the API endpoint `/api/settings/privacy-policies/public`.
+
+## What Was Implemented
+
+### 1. Data Layer
+
+#### Models (`lib/features/settings/data/models/`)
+- **privacy_policy_model.dart**: Contains three models:
+  - `PrivacyPolicyModel`: Represents a single privacy policy with fields:
+    - `id` (mapped from `_id`)
+    - `title`
+    - `content`
+    - `createdAt`
+    - `updatedAt`
+  - `PrivacyPoliciesDataModel`: Contains the list of policies
+  - `PrivacyPoliciesResponseModel`: Wraps the API response with success, statusCode, message, and data
+
+- **privacy_policy_model.g.dart**: Generated JSON serialization code
+
+#### Data Sources (`lib/features/settings/data/data_sources/`)
+- **settings_remote_datasource.dart**: Abstract interface
+- **settings_remote_datasource_impl.dart**: Implementation that calls the API endpoint
+
+#### Repositories (`lib/features/settings/data/repositories/`)
+- **settings_repository.dart**: Abstract repository interface
+- **settings_repository_impl.dart**: Implementation with error handling using `Either` type
+
+### 2. Business Logic Layer
+
+#### Cubit (`lib/features/settings/logic/`)
+- **privacy_policy_cubit.dart**: Manages privacy policy state
+- **privacy_policy_state.dart**: Contains:
+  - `loadingState` (initial, loading, success, failure)
+  - `policies` (list of privacy policies)
+  - `errorMessage` (optional error message)
+
+### 3. Presentation Layer
+
+#### Screens (`lib/features/settings/presentation/screens/`)
+- **privacy_policy_screen.dart**: 
+  - Implements `AutoRouteWrapper` for dependency injection
+  - Displays policies in a scrollable list with cards
+  - Shows loading animation while fetching
+  - Shows error widget with retry button on failure
+  - Shows empty state message when no policies exist
+  - Each policy card displays the title and content
+
+### 4. Routing & Navigation
+
+#### Updates Made:
+- **app_router.dart**: Added `PrivacyPolicyRoute` to authenticated routes
+- **profile_body_component.dart**: Added "Privacy Policy" menu item in "App Settings" section with shield icon
+
+### 5. API Integration
+
+#### Updates Made:
+- **api_constants.dart**: Added constant `privacyPolicies = "/settings/privacy-policies/public"`
+
+### 6. Dependency Injection
+
+#### Updates Made:
+- **injection.config.dart**: Added registrations for:
+  - `SettingsRemoteDatasource`
+  - `SettingsRepository`
+  - `PrivacyPolicyCubit`
+
+### 7. Localization
+
+#### Added Translations:
+- **intl_en.arb**: 
+  - `"privacyPolicy": "Privacy Policy"`
+  - `"noPrivacyPoliciesAvailable": "No privacy policies available at the moment"`
+  
+- **intl_ar.arb**: 
+  - `"privacyPolicy": "سياسة الخصوصية"`
+  - `"noPrivacyPoliciesAvailable": "لا توجد سياسات خصوصية متاحة في الوقت الحالي"`
+
+## How It Works
+
+1. User opens the app and navigates to Profile screen
+2. User taps on "Privacy Policy" in the "App Settings" section
+3. The app navigates to `PrivacyPolicyScreen`
+4. The screen automatically triggers `PrivacyPolicyCubit.getPrivacyPolicies()`
+5. The cubit calls the repository, which calls the remote data source
+6. The data source makes a GET request to `/settings/privacy-policies/public`
+7. The response is parsed into `PrivacyPoliciesResponseModel`
+8. The policies are displayed in a scrollable list with cards
+
+## UI Features
+
+- **App Bar**: Shows "Privacy Policy" title with back button
+- **Loading State**: Displays a loading animation while fetching data
+- **Success State**: Shows policies in cards with:
+  - Title in bold with primary color
+  - Content with proper line height and text wrapping
+- **Error State**: Shows error widget with retry button
+- **Empty State**: Shows "No privacy policies available" message
+- **RTL Support**: Properly handles Arabic text direction
+
+## API Response Structure
+
+The implementation expects the following response format:
+
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "message": "Privacy Policies retrieved successfully",
+  "data": {
+    "policies": [
+      {
+        "_id": "68e1cf8d0379dcd9f98084b2",
+        "title": "تيست",
+        "content": "تيست",
+        "createdAt": "2025-10-05T01:53:17.088Z",
+        "updatedAt": "2025-10-05T01:53:17.088Z"
+      }
+    ]
+  }
+}
+```
+
+## Testing
+
+To test the implementation:
+
+1. Run the app
+2. Navigate to Profile tab
+3. Scroll down to "App Settings" section
+4. Tap on "Privacy Policy"
+5. Verify that policies are displayed correctly
+
+## Troubleshooting
+
+If you see a white screen, check:
+
+1. **API Response**: Ensure the API is returning data in the correct format
+2. **Network Connection**: Verify the device has internet connectivity
+3. **API Endpoint**: Confirm the base URL is correctly configured
+4. **Build Runner**: Run `flutter pub run build_runner build --delete-conflicting-outputs` to regenerate files
+5. **Dependencies**: Run `flutter pub get` to ensure all packages are installed
+
+## Files Created
+
+```
+lib/features/settings/
+├── data/
+│   ├── data_sources/
+│   │   ├── settings_remote_datasource.dart
+│   │   └── settings_remote_datasource_impl.dart
+│   ├── models/
+│   │   ├── privacy_policy_model.dart
+│   │   └── privacy_policy_model.g.dart
+│   └── repositories/
+│       ├── settings_repository.dart
+│       └── settings_repository_impl.dart
+├── logic/
+│   ├── privacy_policy_cubit.dart
+│   └── privacy_policy_state.dart
+└── presentation/
+    └── screens/
+        └── privacy_policy_screen.dart
+```
+
+## Files Modified
+
+- `lib/core/constants/api_constants.dart`
+- `lib/core/injection/injection.config.dart`
+- `lib/settings/router/app_router.dart`
+- `lib/features/user/presentation/components/profile/profile_body_component.dart`
+- `lib/l10n/intl_en.arb`
+- `lib/l10n/intl_ar.arb`
+
+## Next Steps
+
+1. Run `flutter pub run build_runner build --delete-conflicting-outputs` to regenerate router files
+2. Run `flutter pub get` to ensure dependencies are installed
+3. Test the feature on both iOS and Android
+4. Test with empty response to verify empty state
+5. Test with network error to verify error handling

--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -46,6 +46,7 @@ class ApiConstants {
   static const String notInterestedToReview =
       "/review/not-interested-to-review";
   static const String getMissedReviews = "/review/missed-review";
+  static const String privacyPolicies = "/settings/privacy-policies/public";
 
   static String getBrandDeliveryFees(String brandId) =>
       "/brand/$brandId/delivery-fees";

--- a/lib/core/injection/injection.config.dart
+++ b/lib/core/injection/injection.config.dart
@@ -127,6 +127,16 @@ import 'package:dazzify/features/reels/data/repositories/reels_repository.dart'
 import 'package:dazzify/features/reels/data/repositories/reels_repository_impl.dart'
     as _i255;
 import 'package:dazzify/features/reels/logic/reels_bloc.dart' as _i468;
+import 'package:dazzify/features/settings/data/data_sources/settings_remote_datasource.dart'
+    as _i900;
+import 'package:dazzify/features/settings/data/data_sources/settings_remote_datasource_impl.dart'
+    as _i901;
+import 'package:dazzify/features/settings/data/repositories/settings_repository.dart'
+    as _i902;
+import 'package:dazzify/features/settings/data/repositories/settings_repository_impl.dart'
+    as _i903;
+import 'package:dazzify/features/settings/logic/privacy_policy_cubit.dart'
+    as _i904;
 import 'package:dazzify/features/shared/data/data_sources/local/local_datasource.dart'
     as _i422;
 import 'package:dazzify/features/shared/data/repositories/local_repository/local_repository.dart'
@@ -273,6 +283,12 @@ extension GetItInjectableX on _i174.GetIt {
         () => _i786.PaymentRepositoryImpl(gh<_i46.PaymentRemoteDataSource>()));
     gh.lazySingleton<_i775.ChatRepository>(
         () => _i1048.ChatRepositoryImpl(gh<_i425.ChatRemoteDatasource>()));
+    gh.lazySingleton<_i900.SettingsRemoteDatasource>(
+        () => _i901.SettingsRemoteDatasourceImpl(apiConsumer: gh<_i373.ApiConsumer>()));
+    gh.lazySingleton<_i902.SettingsRepository>(
+        () => _i903.SettingsRepositoryImpl(remoteDataSource: gh<_i900.SettingsRemoteDatasource>()));
+    gh.factory<_i904.PrivacyPolicyCubit>(
+        () => _i904.PrivacyPolicyCubit(settingsRepository: gh<_i902.SettingsRepository>()));
     gh.lazySingleton<_i716.BookingRemoteDatasource>(
         () => _i210.BookingRemoteDatasourceImpl(gh<_i373.ApiConsumer>()));
     gh.lazySingleton<_i447.BrandRepository>(

--- a/lib/features/settings/data/data_sources/settings_remote_datasource.dart
+++ b/lib/features/settings/data/data_sources/settings_remote_datasource.dart
@@ -1,0 +1,5 @@
+import 'package:dazzify/features/settings/data/models/privacy_policy_model.dart';
+
+abstract class SettingsRemoteDatasource {
+  Future<PrivacyPoliciesResponseModel> getPrivacyPolicies();
+}

--- a/lib/features/settings/data/data_sources/settings_remote_datasource_impl.dart
+++ b/lib/features/settings/data/data_sources/settings_remote_datasource_impl.dart
@@ -1,0 +1,18 @@
+import 'package:dazzify/core/api/api_consumer.dart';
+import 'package:dazzify/core/constants/api_constants.dart';
+import 'package:dazzify/features/settings/data/data_sources/settings_remote_datasource.dart';
+import 'package:dazzify/features/settings/data/models/privacy_policy_model.dart';
+import 'package:injectable/injectable.dart';
+
+@LazySingleton(as: SettingsRemoteDatasource)
+class SettingsRemoteDatasourceImpl implements SettingsRemoteDatasource {
+  final ApiConsumer apiConsumer;
+
+  SettingsRemoteDatasourceImpl({required this.apiConsumer});
+
+  @override
+  Future<PrivacyPoliciesResponseModel> getPrivacyPolicies() async {
+    final response = await apiConsumer.get(ApiConstants.privacyPolicies);
+    return PrivacyPoliciesResponseModel.fromJson(response);
+  }
+}

--- a/lib/features/settings/data/models/privacy_policy_model.dart
+++ b/lib/features/settings/data/models/privacy_policy_model.dart
@@ -1,0 +1,60 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'privacy_policy_model.g.dart';
+
+@JsonSerializable()
+class PrivacyPolicyModel {
+  @JsonKey(name: '_id')
+  final String id;
+  final String title;
+  final String content;
+  final String createdAt;
+  final String updatedAt;
+
+  PrivacyPolicyModel({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory PrivacyPolicyModel.fromJson(Map<String, dynamic> json) =>
+      _$PrivacyPolicyModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PrivacyPolicyModelToJson(this);
+}
+
+@JsonSerializable()
+class PrivacyPoliciesResponseModel {
+  final bool success;
+  final int statusCode;
+  final String message;
+  final PrivacyPoliciesDataModel data;
+
+  PrivacyPoliciesResponseModel({
+    required this.success,
+    required this.statusCode,
+    required this.message,
+    required this.data,
+  });
+
+  factory PrivacyPoliciesResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$PrivacyPoliciesResponseModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PrivacyPoliciesResponseModelToJson(this);
+}
+
+@JsonSerializable()
+class PrivacyPoliciesDataModel {
+  final List<PrivacyPolicyModel> policies;
+
+  PrivacyPoliciesDataModel({
+    required this.policies,
+  });
+
+  factory PrivacyPoliciesDataModel.fromJson(Map<String, dynamic> json) =>
+      _$PrivacyPoliciesDataModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PrivacyPoliciesDataModelToJson(this);
+}

--- a/lib/features/settings/data/models/privacy_policy_model.g.dart
+++ b/lib/features/settings/data/models/privacy_policy_model.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'privacy_policy_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PrivacyPolicyModel _$PrivacyPolicyModelFromJson(Map<String, dynamic> json) =>
+    PrivacyPolicyModel(
+      id: json['_id'] as String,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      createdAt: json['createdAt'] as String,
+      updatedAt: json['updatedAt'] as String,
+    );
+
+Map<String, dynamic> _$PrivacyPolicyModelToJson(PrivacyPolicyModel instance) =>
+    <String, dynamic>{
+      '_id': instance.id,
+      'title': instance.title,
+      'content': instance.content,
+      'createdAt': instance.createdAt,
+      'updatedAt': instance.updatedAt,
+    };
+
+PrivacyPoliciesResponseModel _$PrivacyPoliciesResponseModelFromJson(
+        Map<String, dynamic> json) =>
+    PrivacyPoliciesResponseModel(
+      success: json['success'] as bool,
+      statusCode: (json['statusCode'] as num).toInt(),
+      message: json['message'] as String,
+      data: PrivacyPoliciesDataModel.fromJson(
+          json['data'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$PrivacyPoliciesResponseModelToJson(
+        PrivacyPoliciesResponseModel instance) =>
+    <String, dynamic>{
+      'success': instance.success,
+      'statusCode': instance.statusCode,
+      'message': instance.message,
+      'data': instance.data,
+    };
+
+PrivacyPoliciesDataModel _$PrivacyPoliciesDataModelFromJson(
+        Map<String, dynamic> json) =>
+    PrivacyPoliciesDataModel(
+      policies: (json['policies'] as List<dynamic>)
+          .map((e) => PrivacyPolicyModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PrivacyPoliciesDataModelToJson(
+        PrivacyPoliciesDataModel instance) =>
+    <String, dynamic>{
+      'policies': instance.policies,
+    };

--- a/lib/features/settings/data/repositories/settings_repository.dart
+++ b/lib/features/settings/data/repositories/settings_repository.dart
@@ -1,0 +1,8 @@
+import 'package:dartz/dartz.dart';
+import 'package:dazzify/core/api/network_exceptions.dart';
+import 'package:dazzify/features/settings/data/models/privacy_policy_model.dart';
+
+abstract class SettingsRepository {
+  Future<Either<NetworkExceptions, PrivacyPoliciesResponseModel>>
+      getPrivacyPolicies();
+}

--- a/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -1,0 +1,24 @@
+import 'package:dartz/dartz.dart';
+import 'package:dazzify/core/api/network_exceptions.dart';
+import 'package:dazzify/features/settings/data/data_sources/settings_remote_datasource.dart';
+import 'package:dazzify/features/settings/data/models/privacy_policy_model.dart';
+import 'package:dazzify/features/settings/data/repositories/settings_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@LazySingleton(as: SettingsRepository)
+class SettingsRepositoryImpl implements SettingsRepository {
+  final SettingsRemoteDatasource remoteDataSource;
+
+  SettingsRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Either<NetworkExceptions, PrivacyPoliciesResponseModel>>
+      getPrivacyPolicies() async {
+    try {
+      final response = await remoteDataSource.getPrivacyPolicies();
+      return Right(response);
+    } catch (e) {
+      return Left(NetworkExceptions.getDioException(e));
+    }
+  }
+}

--- a/lib/features/settings/logic/privacy_policy_cubit.dart
+++ b/lib/features/settings/logic/privacy_policy_cubit.dart
@@ -1,0 +1,36 @@
+import 'package:bloc/bloc.dart';
+import 'package:dazzify/core/util/enums.dart';
+import 'package:dazzify/features/settings/data/models/privacy_policy_model.dart';
+import 'package:dazzify/features/settings/data/repositories/settings_repository.dart';
+import 'package:injectable/injectable.dart';
+
+part 'privacy_policy_state.dart';
+
+@injectable
+class PrivacyPolicyCubit extends Cubit<PrivacyPolicyState> {
+  final SettingsRepository settingsRepository;
+
+  PrivacyPolicyCubit({required this.settingsRepository})
+      : super(PrivacyPolicyState());
+
+  Future<void> getPrivacyPolicies() async {
+    emit(state.copyWith(loadingState: UiState.loading));
+
+    final result = await settingsRepository.getPrivacyPolicies();
+
+    result.fold(
+      (error) {
+        emit(state.copyWith(
+          loadingState: UiState.failure,
+          errorMessage: error.toString(),
+        ));
+      },
+      (response) {
+        emit(state.copyWith(
+          loadingState: UiState.success,
+          policies: response.data.policies,
+        ));
+      },
+    );
+  }
+}

--- a/lib/features/settings/logic/privacy_policy_state.dart
+++ b/lib/features/settings/logic/privacy_policy_state.dart
@@ -1,0 +1,25 @@
+part of 'privacy_policy_cubit.dart';
+
+class PrivacyPolicyState {
+  final UiState loadingState;
+  final List<PrivacyPolicyModel> policies;
+  final String? errorMessage;
+
+  PrivacyPolicyState({
+    this.loadingState = UiState.initial,
+    this.policies = const [],
+    this.errorMessage,
+  });
+
+  PrivacyPolicyState copyWith({
+    UiState? loadingState,
+    List<PrivacyPolicyModel>? policies,
+    String? errorMessage,
+  }) {
+    return PrivacyPolicyState(
+      loadingState: loadingState ?? this.loadingState,
+      policies: policies ?? this.policies,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/settings/presentation/screens/privacy_policy_screen.dart
+++ b/lib/features/settings/presentation/screens/privacy_policy_screen.dart
@@ -1,0 +1,121 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:dazzify/core/framework/export.dart';
+import 'package:dazzify/core/injection/injection.dart';
+import 'package:dazzify/core/util/enums.dart';
+import 'package:dazzify/features/settings/logic/privacy_policy_cubit.dart';
+import 'package:dazzify/features/shared/animations/loading_animation.dart';
+import 'package:dazzify/features/shared/widgets/error_data_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+@RoutePage()
+class PrivacyPolicyScreen extends StatefulWidget implements AutoRouteWrapper {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget wrappedRoute(BuildContext context) {
+    return BlocProvider(
+      create: (context) => getIt<PrivacyPolicyCubit>()..getPrivacyPolicies(),
+      child: this,
+    );
+  }
+
+  @override
+  State<PrivacyPolicyScreen> createState() => _PrivacyPolicyScreenState();
+}
+
+class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: DText(
+          context.tr.privacyPolicy,
+          style: context.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: true,
+        leading: IconButton(
+          icon: Icon(
+            context.currentTextDirection == TextDirection.ltr
+                ? Icons.arrow_back_ios
+                : Icons.arrow_forward_ios,
+          ),
+          onPressed: () => context.maybePop(),
+        ),
+      ),
+      body: BlocBuilder<PrivacyPolicyCubit, PrivacyPolicyState>(
+        builder: (context, state) {
+          if (state.loadingState == UiState.loading) {
+            return Center(
+              child: LoadingAnimation(
+                height: 70.h,
+                width: 70.w,
+              ),
+            );
+          } else if (state.loadingState == UiState.failure) {
+            return ErrorDataWidget(
+              onRetry: () {
+                context.read<PrivacyPolicyCubit>().getPrivacyPolicies();
+              },
+            );
+          } else if (state.loadingState == UiState.success) {
+            if (state.policies.isEmpty) {
+              return Center(
+                child: DText(
+                  context.tr.noPrivacyPoliciesAvailable,
+                  style: context.textTheme.bodyLarge?.copyWith(
+                    color: context.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              );
+            }
+
+            return ListView.builder(
+              padding: EdgeInsets.all(16.r),
+              itemCount: state.policies.length,
+              itemBuilder: (context, index) {
+                final policy = state.policies[index];
+                return Card(
+                  margin: EdgeInsets.only(bottom: 16.h),
+                  elevation: 2,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.r),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.all(16.r),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        DText(
+                          policy.title,
+                          style: context.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: context.colorScheme.primary,
+                          ),
+                        ),
+                        SizedBox(height: 12.h),
+                        DText(
+                          policy.content,
+                          style: context.textTheme.bodyMedium?.copyWith(
+                            color: context.colorScheme.onSurfaceVariant,
+                            height: 1.5,
+                          ),
+                          softWrap: true,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/user/presentation/components/profile/profile_body_component.dart
+++ b/lib/features/user/presentation/components/profile/profile_body_component.dart
@@ -164,6 +164,13 @@ class _ProfileBodyComponentState extends State<ProfileBodyComponent> {
             children: Column(
               children: [
                 ProfileCustomListTile(
+                  iconData: SolarIconsOutline.shieldCheck,
+                  title: context.tr.privacyPolicy,
+                  onTap: () {
+                    context.pushRoute(const PrivacyPolicyRoute());
+                  },
+                ),
+                ProfileCustomListTile(
                   iconData: Icons.language_outlined,
                   title: context.tr.language,
                   suffixWidget: BlocBuilder<SettingsCubit, SettingsState>(

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -405,6 +405,8 @@
   "notes": "الملاحظات",
   "iAgreeToTerms": "أوافق على الشروط والأحكام",
   "noServicesAtThisCategory": "لا توجد خدمات حالياً في هذا القسم",
-  "pleaseApplyCoupon": "يرجى تطبيق رمز الكوبون قبل التأكيد"
+  "pleaseApplyCoupon": "يرجى تطبيق رمز الكوبون قبل التأكيد",
+  "privacyPolicy": "سياسة الخصوصية",
+  "noPrivacyPoliciesAvailable": "لا توجد سياسات خصوصية متاحة في الوقت الحالي"
 
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -405,6 +405,8 @@
   "writeNotes": "Write Notes For Provider",
   "notes": "Notes",
   "iAgreeToTerms": "I agree to the terms",
-  "pleaseApplyCoupon": "Please apply the coupon code before confirming"
+  "pleaseApplyCoupon": "Please apply the coupon code before confirming",
+  "privacyPolicy": "Privacy Policy",
+  "noPrivacyPoliciesAvailable": "No privacy policies available at the moment"
 
 }

--- a/lib/settings/router/app_router.dart
+++ b/lib/settings/router/app_router.dart
@@ -59,6 +59,7 @@ import 'package:dazzify/features/shared/widgets/dazzify_photo_viewer.dart';
 import 'package:dazzify/features/shared/widgets/dazzify_toast_bar.dart';
 import 'package:dazzify/features/shared/widgets/maintenance_screen.dart';
 import 'package:dazzify/features/shared/widgets/splash_screen.dart';
+import 'package:dazzify/features/settings/presentation/screens/privacy_policy_screen.dart';
 import 'package:dazzify/features/shared/widgets/web_view_screen.dart';
 import 'package:dazzify/features/user/logic/issue/issue_bloc.dart';
 import 'package:dazzify/features/user/logic/user/user_cubit.dart';
@@ -358,6 +359,11 @@ class AppRouter extends RootStackRouter {
             ),
             CustomRoute(
               page: WebViewRoute.page,
+              transitionsBuilder: TransitionsBuilders.fadeIn,
+              durationInMilliseconds: 300,
+            ),
+            CustomRoute(
+              page: PrivacyPolicyRoute.page,
               transitionsBuilder: TransitionsBuilders.fadeIn,
               durationInMilliseconds: 300,
             ),


### PR DESCRIPTION
Add the complete Privacy Policy feature to display policies fetched from the API.

The `PrivacyPolicyView` was showing a white screen because the feature was not implemented, despite the API successfully returning privacy policy data. This PR introduces the necessary models, data sources, repository, state management (Cubit), and UI to correctly fetch and display the policies.

---
<a href="https://cursor.com/background-agent?bcId=bc-26f5c1e5-7b20-4f4a-9c33-44a0b6bc609a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26f5c1e5-7b20-4f4a-9c33-44a0b6bc609a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

